### PR TITLE
fix: invalid peer dep version specified for React Native

### DIFF
--- a/packages/rn-mdx/package.json
+++ b/packages/rn-mdx/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "react": ">=17.*",
-    "react-native": ">=64.*"
+    "react-native": ">=0.64.*"
   },
   "dependencies": {
     "@mdx-js/runtime": "^2.0.0-next.9",


### PR DESCRIPTION
### NPM install err
```bash
npm ERR! Found: react-native@0.69.1
npm ERR! node_modules/react-native
npm ERR!   react-native@"0.69.1" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer react-native@">=64.*" from rn-mdx@0.0.6
npm ERR! node_modules/rn-mdx
npm ERR!   rn-mdx@"*" from the root project
```

Related issue https://github.com/danieldunderfelt/rn-mdx/issues/1

